### PR TITLE
Prevents appending a new entry in the AndroidManifest.xml

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -23,9 +23,9 @@
                     value="com.google.cordova.plugin.browsertab.BrowserTab" />
             </feature>
         </config-file>
-        <config-file parent="/*" target="AndroidManifest.xml">
+        <edit-config parent="/*" target="AndroidManifest.xml">
             <uses-sdk android:minSdkVersion="16" />
-        </config-file>
+        </edit-config>
         <source-file src="src/android/BrowserTab.java"
             target-dir="src/com/google/cordova/plugin" />
         <framework src="com.android.support:customtabs:23.3.0"/>


### PR DESCRIPTION
This plugin adds a new `<uses-sdk />` entry in the AndroidManifest file apart from the one that is appended by the Cordova build process. When building the application in release mode it throws an error due to multiple `<uses-sdk>` elements.

I'm basically replacing `config-file`, that appends a new entry in the AndroidManifest file, with `edit-config` that modifies existing elements using a merge strategy.