### PR TITLE
Fixes Android minSdkVersion override

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@
 Iain McGinniss <iainmcgin@google.com>
 William Denniss <wdenniss@google.com>
 Rahul Ravikumar <rahulrav@google.com>
+Zachary Cardoza <bayssmekanique@live.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,4 +9,4 @@
 Iain McGinniss <iainmcgin@google.com>
 William Denniss <wdenniss@google.com>
 Rahul Ravikumar <rahulrav@google.com>
-Zachary Cardoza <bayssmekanique@live.com>
+Zachary Cardoza <bayssmekanique@gmail.com>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -23,12 +23,10 @@
                     value="com.google.cordova.plugin.browsertab.BrowserTab" />
             </feature>
         </config-file>
-        <edit-config parent="/*" target="AndroidManifest.xml">
-            <uses-sdk android:minSdkVersion="16" />
-        </edit-config>
         <source-file src="src/android/BrowserTab.java"
             target-dir="src/com/google/cordova/plugin" />
         <framework src="com.android.support:customtabs:23.3.0"/>
+        <framework src="src/android/BrowserTab.gradle" custom="true" type="gradleReference"/>
     </platform>
 
     <platform name="ios">

--- a/plugin/src/android/BrowserTab.gradle
+++ b/plugin/src/android/BrowserTab.gradle
@@ -1,0 +1,7 @@
+def minSdkVersion = 16
+
+if(cdvMinSdkVersion == null) {
+    ext.cdvMinSdkVersion = minSdkVersion;
+} else if (cdvMinSdkVersion.toInteger() < minSdkVersion) {
+    ext.cdvMinSdkVersion = minSdkVersion;
+}


### PR DESCRIPTION
This removes the minSDK from being automatically added to the `AndroidManifest.xml` file and instead checks that a sufficient minSdkVersion only sets a minSdkVersion when necessary.

Fixes issue: https://github.com/google/cordova-plugin-browsertab/issues/7
