### PR TITLE
Add support for `CUSTOM_TAB_COLOR_RGB` parameter to customize browser tab background (only Android supported at the moment)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,2 @@
+### 0.2.1
+* Add support for `CUSTOM_TAB_COLOR_RGB` parameter to customize browser tab background (only Android supported at the moment)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -50,6 +50,20 @@ Complete example with fallback handling:
       });
     });
 
+## Customization
+
+Plugin can be customized by providing parameters during installation.
+You can customize i.e. custom tab background color by passing `CUSTOM_TAB_COLOR_RGB` variable in string RGB format:
+
+```bash
+cordova plugin add cordova-plugin-browsertab --variable CUSTOM_TAB_COLOR_RGB="#ff0000"
+```
+
+List of available parameters:
+
+* **CUSTOM_TAB_COLOR_RGB** - Customize custom tab background color. Pass value as a RGB string `#RRGGBB`.
+                            Supported by Android only at the moment.
+
 ## Building
 
 Install Cordova if you haven't already:

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-browsertab",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "In-app browser tabs for Android and iOS",
     "cordova": {
         "id": "cordova-plugin-browsertab",

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -3,7 +3,7 @@
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-browsertab"
-    version="0.2.0">
+    version="0.2.1">
     <name>cordova-plugin-browsertab</name>
     <description>
         This plugin provides an interface to in-app browser tabs that exist on

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -15,7 +15,9 @@
     <js-module name="BrowserTab" src="www/browsertab.js">
         <clobbers target="cordova.plugins.browsertab" />
     </js-module>
-
+  
+    <preference name="CUSTOM_TAB_COLOR_RGB" default="#ffffff" />
+  
     <platform name="android">
         <config-file parent="/*" target="res/xml/config.xml">
             <feature name="BrowserTab">
@@ -27,6 +29,11 @@
             target-dir="src/com/google/cordova/plugin" />
         <framework src="com.android.support:customtabs:23.3.0"/>
         <framework src="src/android/BrowserTab.gradle" custom="true" type="gradleReference"/>
+  
+        <source-file src="src/android/res/browsertab.xml" target-dir="res/values" />
+        <config-file target="res/values/browsertab.xml" parent="/*">
+          <string name="CUSTOM_TAB_COLOR_RGB">$CUSTOM_TAB_COLOR_RGB</string>
+        </config-file>
     </platform>
 
     <platform name="ios">

--- a/plugin/src/android/BrowserTab.java
+++ b/plugin/src/android/BrowserTab.java
@@ -34,6 +34,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.graphics.Color;
+
 /**
  * Cordova plugin which provides the ability to launch a URL in an
  * in-app browser tab. On Android, this means using the custom tabs support
@@ -44,6 +46,8 @@ public class BrowserTab extends CordovaPlugin {
   public static final int RC_OPEN_URL = 101;
 
   private static final String LOG_TAG = "BrowserTab";
+
+  private Color colorParser = new Color();
 
   /**
    * The service we expect to find on a web browser that indicates it supports custom tabs.
@@ -101,10 +105,18 @@ public class BrowserTab extends CordovaPlugin {
       callbackContext.error("no in app browser tab implementation available");
     }
 
-    Intent customTabsIntent = new CustomTabsIntent.Builder().build().intent;
-    customTabsIntent.setData(Uri.parse(urlStr));
-    customTabsIntent.setPackage(mCustomTabsBrowser);
-    cordova.getActivity().startActivity(customTabsIntent);
+    // Initialize Builder
+    CustomTabsIntent.Builder customTabsIntentBuilder = new CustomTabsIntent.Builder();
+
+    // Set tab color
+    String tabColor = cordova.getActivity().getString(cordova.getActivity().getResources().getIdentifier("CUSTOM_TAB_COLOR_RGB", "string", cordova.getActivity().getPackageName()));
+    customTabsIntentBuilder.setToolbarColor(colorParser.parseColor(tabColor));
+
+    // Create Intent
+    CustomTabsIntent customTabsIntent = customTabsIntentBuilder.build();
+
+    // Load URL
+    customTabsIntent.launchUrl(cordova.getActivity(), Uri.parse(urlStr));
 
     Log.d(LOG_TAG, "in app browser call dispatched");
     callbackContext.success();

--- a/plugin/src/android/res/browsertab.xml
+++ b/plugin/src/android/res/browsertab.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+</resources>


### PR DESCRIPTION
- Added support for `CUSTOM_TAB_COLOR_RGB` param. Usage: `cordova plugin add cordova-plugin-browsertab --variable CUSTOM_TAB_COLOR_RGB="#ff0000"` to setup custom Android (only Android supported now) browser tab to red background.
- Updated code that creates new CustomTabIntent to be up to date with most recent Google docs (https://developer.chrome.com/multidevice/android/customtabs#opening-a chrome custom tab)
- Bump version to `0.2.1`
- Added `RELEASENOTES.md` file to write down releases changelog
- Updated readme