### PR TITLE
Min sdk version from 16 to 19 on android

### DIFF
--- a/plugin/src/android/BrowserTab.gradle
+++ b/plugin/src/android/BrowserTab.gradle
@@ -1,4 +1,4 @@
-def minSdkVersion = 16
+def minSdkVersion = 19
 
 if(cdvMinSdkVersion == null) {
     ext.cdvMinSdkVersion = minSdkVersion;


### PR DESCRIPTION
The plugin code should be updated to match the latest android api sdk calls, at lest at version 19. For now, just changing the version for cordova build, but this may not assure the plugin works under version 19 or higher of android api.