### PR TITLE
🔥 Removing `minSdkVersion` to `build.gradle`

### DIFF
--- a/plugin/src/android/BrowserTab.gradle
+++ b/plugin/src/android/BrowserTab.gradle
@@ -1,7 +1,1 @@
-def minSdkVersion = 16
 
-if(cdvMinSdkVersion == null) {
-    ext.cdvMinSdkVersion = minSdkVersion;
-} else if (cdvMinSdkVersion.toInteger() < minSdkVersion) {
-    ext.cdvMinSdkVersion = minSdkVersion;
-}


### PR DESCRIPTION
When compiled using Cordova v11.0.0 and cordova-android v10.1.2 the following error occurs:

> Could not get unknown property 'cdvMinSdkVersion' for project ':app' of type org.gradle.api.Project.

Removing the lines below the problem solves the above error.

I don't know if it's the best solution, but it seems to work for me.